### PR TITLE
Client register

### DIFF
--- a/tiled/_tests/test_container_fields.py
+++ b/tiled/_tests/test_container_fields.py
@@ -7,8 +7,8 @@ import pytest
 import zarr
 
 from ..catalog import in_memory
-from ..catalog.register import register
 from ..client import Context, from_context, record_history
+from ..client.register import register
 from ..examples.generate_files import generate_files
 from ..server.app import build_app
 
@@ -20,7 +20,7 @@ def client(request: pytest.FixtureRequest):
     catalog = in_memory(readable_storage=[data_dir])
     with Context.from_app(build_app(catalog)) as context:
         client = from_context(context)
-        anyio.run(register, catalog, data_dir)
+        anyio.run(register, client, data_dir)
         yield client
 
 

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -1083,7 +1083,7 @@ async def post_metadata(
                 "Externally-managed assets cannot be registered "
                 "using POST /metadata/{path} Use POST /register/{path} instead."
             )
-    if not getattr(entry, "writable", False):
+    if body.data_sources and not getattr(entry, "writable", False):
         raise HTTPException(
             status_code=405, detail=f"Data cannot be written at the path {path}"
         )


### PR DESCRIPTION
Fulfills 1st item in https://github.com/bluesky/tiled/pull/661#issuecomment-1958104019 :
- [x] Update tests pulled in from rebase on https://github.com/bluesky/tiled/pull/660.

This update enforces writeable storage for `POST /metadata` **ONLY** when the requested node also has data sources. This enables the top level directory/container to be registered in the catalog.